### PR TITLE
Lock quequed jobs to version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
 	"require":
 	{
 		"silverstripe/cms": "^3.0.0",
-		"silverstripe/queuedjobs": "dev-master"
+		"silverstripe/queuedjobs": "^2.8.6"
 	}
 }


### PR DESCRIPTION
Locks down the Queued Jobs version so the latest master commit isn't pulled in. Pulling in the latest master could introduce breaking changes by mistake.