### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	],
 	"require":
 	{
-		"silverstripe/cms": ">=3.0.0",
+		"silverstripe/cms": "^3.0.0",
 		"silverstripe/queuedjobs": "dev-master"
 	}
 }


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.